### PR TITLE
Show correct format default

### DIFF
--- a/docs/documentation/getting-started/configuration/index.markdown
+++ b/docs/documentation/getting-started/configuration/index.markdown
@@ -132,7 +132,7 @@ The following variables are settable:
   * Used in SSHKit.
 
 * `:format`
-  * **default:** `:pretty`
+  * **default:** `:airbrussh`
   * Used in SSHKit.
 
 


### PR DESCRIPTION
Format defaults changed from 'pretty' to 'airbrussh' in 3.5. Updating docs to reflect change.